### PR TITLE
migrate to stable api

### DIFF
--- a/playwright_stealth/js/chrome.runtime.js
+++ b/playwright_stealth/js/chrome.runtime.js
@@ -56,7 +56,6 @@ const existsAlready = 'runtime' in window.chrome
 // `chrome.runtime` is only exposed on secure origins
 const isNotSecure = !window.location.protocol.startsWith('https')
 if (!(existsAlready || (isNotSecure && !opts.runOnInsecureOrigins))) {
-    log.info('loading chrome.runtime.js')
     window.chrome.runtime = {
         // There's a bunch of static data in that property which doesn't seem to change,
         // we should periodically check for updates: `JSON.stringify(window.chrome.runtime, null, 2)`

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -136,10 +136,10 @@ class StealthConfig:
 def stealth_sync(page: SyncPage, config: StealthConfig = None):
     """teaches synchronous playwright Page to be stealthy like a ninja!"""
     for script in (config or StealthConfig()).enabled_scripts:
-        page.addInitScript(script)
+        page.add_init_script(script)
 
 
 async def stealth_async(page: AsyncPage, config: StealthConfig = None):
     """teaches asynchronous playwright Page to be stealthy like a ninja!"""
     for script in (config or StealthConfig()).enabled_scripts:
-        await page.addInitScript(script)
+        await page.add_init_script(script)


### PR DESCRIPTION
The API has changed since the last 0.170.0 version:

Snake case notation for methods and arguments:

```python
# old
browser.newPage()
# new
browser.new_page()
```