### PR TITLE
fix typo: `navigator_plaftorm` -> `navigator_platform`

### DIFF
--- a/playwright_stealth/js/navigator.platform.js
+++ b/playwright_stealth/js/navigator.platform.js
@@ -1,5 +1,5 @@
 if (opts.navigator_platform) {
     Object.defineProperty(Object.getPrototypeOf(navigator), 'platform', {
-        get: () => opts.navigator_plaftorm,
+        get: () => opts.navigator_platform,
     })
 }


### PR DESCRIPTION
Overriding navigator_platform doesn't work because of this typo
`navigator.platform` returns `undefinned`:
![image](https://github.com/AtuboDad/playwright_stealth/assets/14761219/aa85649f-224c-460b-9493-d5dd27531f5d)

