### PR TITLE
Remove deprecated pkg_resources references

### DIFF
--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -1,38 +1,40 @@
 # -*- coding: utf-8 -*-
 import json
+import os
 from dataclasses import dataclass
 from typing import Tuple, Optional, Dict
 
-import pkg_resources
 from playwright.async_api import Page as AsyncPage
 from playwright.sync_api import Page as SyncPage
 
 
-def from_file(name):
+def from_file(name) -> str:
     """Read script from ./js directory"""
-    return pkg_resources.resource_string('playwright_stealth', f'js/{name}').decode()
+    filename = os.path.join(os.path.dirname(__file__), "js", name)
+    with open(filename, encoding="utf-8") as f:
+        return f.read()
 
 
 SCRIPTS: Dict[str, str] = {
-    'chrome_csi': from_file('chrome.csi.js'),
-    'chrome_app': from_file('chrome.app.js'),
-    'chrome_runtime': from_file('chrome.runtime.js'),
-    'chrome_load_times': from_file('chrome.load.times.js'),
-    'chrome_hairline': from_file('chrome.hairline.js'),
-    'generate_magic_arrays': from_file('generate.magic.arrays.js'),
-    'iframe_content_window': from_file('iframe.contentWindow.js'),
-    'media_codecs': from_file('media.codecs.js'),
-    'navigator_vendor': from_file('navigator.vendor.js'),
-    'navigator_plugins': from_file('navigator.plugins.js'),
-    'navigator_permissions': from_file('navigator.permissions.js'),
-    'navigator_languages': from_file('navigator.languages.js'),
-    'navigator_platform': from_file('navigator.platform.js'),
-    'navigator_user_agent': from_file('navigator.userAgent.js'),
-    'navigator_hardware_concurrency': from_file('navigator.hardwareConcurrency.js'),
-    'outerdimensions': from_file('window.outerdimensions.js'),
-    'utils': from_file('utils.js'),
-    'webdriver': from_file('navigator.webdriver.js'),
-    'webgl_vendor': from_file('webgl.vendor.js'),
+    "chrome_csi": from_file("chrome.csi.js"),
+    "chrome_app": from_file("chrome.app.js"),
+    "chrome_runtime": from_file("chrome.runtime.js"),
+    "chrome_load_times": from_file("chrome.load.times.js"),
+    "chrome_hairline": from_file("chrome.hairline.js"),
+    "generate_magic_arrays": from_file("generate.magic.arrays.js"),
+    "iframe_content_window": from_file("iframe.contentWindow.js"),
+    "media_codecs": from_file("media.codecs.js"),
+    "navigator_vendor": from_file("navigator.vendor.js"),
+    "navigator_plugins": from_file("navigator.plugins.js"),
+    "navigator_permissions": from_file("navigator.permissions.js"),
+    "navigator_languages": from_file("navigator.languages.js"),
+    "navigator_platform": from_file("navigator.platform.js"),
+    "navigator_user_agent": from_file("navigator.userAgent.js"),
+    "navigator_hardware_concurrency": from_file("navigator.hardwareConcurrency.js"),
+    "outerdimensions": from_file("window.outerdimensions.js"),
+    "utils": from_file("utils.js"),
+    "webdriver": from_file("navigator.webdriver.js"),
+    "webgl_vendor": from_file("webgl.vendor.js"),
 }
 
 
@@ -54,6 +56,7 @@ class StealthConfig:
             yield 'console.log("last script")'
         ```
     """
+
     # load script options
     webdriver: bool = True
     webgl_vendor: bool = True
@@ -74,63 +77,65 @@ class StealthConfig:
     hairline: bool = True
 
     # options
-    vendor: str = 'Intel Inc.'
-    renderer: str = 'Intel Iris OpenGL Engine'
-    nav_vendor: str = 'Google Inc.'
+    vendor: str = "Intel Inc."
+    renderer: str = "Intel Iris OpenGL Engine"
+    nav_vendor: str = "Google Inc."
     nav_user_agent: str = None
     nav_platform: str = None
-    languages: Tuple[str] = ('en-US', 'en')
+    languages: Tuple[str] = ("en-US", "en")
     runOnInsecureOrigins: Optional[bool] = None
 
     @property
     def enabled_scripts(self):
-        opts = json.dumps({
-            'webgl_vendor': self.vendor,
-            'webgl_renderer': self.renderer,
-            'navigator_vendor': self.nav_vendor,
-            'navigator_platform': self.nav_platform,
-            'navigator_user_agent': self.nav_user_agent,
-            'languages': list(self.languages),
-            'runOnInsecureOrigins': self.runOnInsecureOrigins,
-        })
+        opts = json.dumps(
+            {
+                "webgl_vendor": self.vendor,
+                "webgl_renderer": self.renderer,
+                "navigator_vendor": self.nav_vendor,
+                "navigator_platform": self.nav_platform,
+                "navigator_user_agent": self.nav_user_agent,
+                "languages": list(self.languages),
+                "runOnInsecureOrigins": self.runOnInsecureOrigins,
+            }
+        )
         # defined options constant
-        yield f'const opts = {opts}'
+        yield f"const opts = {opts}"
         # init utils and generate_magic_arrays helper
-        yield SCRIPTS['utils']
-        yield SCRIPTS['generate_magic_arrays']
+        yield SCRIPTS["utils"]
+        yield SCRIPTS["generate_magic_arrays"]
 
         if self.chrome_app:
-            yield SCRIPTS['chrome_app']
+            yield SCRIPTS["chrome_app"]
         if self.chrome_csi:
-            yield SCRIPTS['chrome_csi']
+            yield SCRIPTS["chrome_csi"]
         if self.hairline:
-            yield SCRIPTS['chrome_hairline']
+            yield SCRIPTS["chrome_hairline"]
         if self.chrome_load_times:
-            yield SCRIPTS['chrome_load_times']
+            yield SCRIPTS["chrome_load_times"]
         if self.chrome_runtime:
-            yield SCRIPTS['chrome_runtime']
+            yield SCRIPTS["chrome_runtime"]
         if self.iframe_content_window:
-            yield SCRIPTS['iframe_content_window']
+            yield SCRIPTS["iframe_content_window"]
         if self.media_codecs:
-            yield SCRIPTS['media_codecs']
+            yield SCRIPTS["media_codecs"]
         if self.navigator_languages:
-            yield SCRIPTS['navigator_languages']
+            yield SCRIPTS["navigator_languages"]
         if self.navigator_permissions:
-            yield SCRIPTS['navigator_permissions']
+            yield SCRIPTS["navigator_permissions"]
         if self.navigator_platform:
-            yield SCRIPTS['navigator_platform']
+            yield SCRIPTS["navigator_platform"]
         if self.navigator_plugins:
-            yield SCRIPTS['navigator_plugins']
+            yield SCRIPTS["navigator_plugins"]
         if self.navigator_user_agent:
-            yield SCRIPTS['navigator_user_agent']
+            yield SCRIPTS["navigator_user_agent"]
         if self.navigator_vendor:
-            yield SCRIPTS['navigator_vendor']
+            yield SCRIPTS["navigator_vendor"]
         if self.webdriver:
-            yield SCRIPTS['webdriver']
+            yield SCRIPTS["webdriver"]
         if self.outerdimensions:
-            yield SCRIPTS['outerdimensions']
+            yield SCRIPTS["outerdimensions"]
         if self.webgl_vendor:
-            yield SCRIPTS['webgl_vendor']
+            yield SCRIPTS["webgl_vendor"]
 
 
 def stealth_sync(page: SyncPage, config: StealthConfig = None):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="playwright-stealth",
-    version="1.0.6",
+    version="1.0.7",
     author="AtuboDad",
     author_email="lcjasas@sina.com",
     description="playwright stealth",
@@ -19,9 +19,13 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     package_data={"playwright_stealth": ["js/*.js"]},
-    python_requires='>=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires=">=3, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     install_requires=[
-       'playwright',
+        "playwright",
     ],
-    extras_require={"test": ["pytest", ]},
+    extras_require={
+        "test": [
+            "pytest",
+        ]
+    },
 )


### PR DESCRIPTION
pkg_resources is deprecated and as of pip 24 (+ Python 3.12) its not working anymore at all.
Replacing with a simple fopen

fixes #22 