### PR TITLE
Replace pkg_resources usage with plain file reading

### DIFF
--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -13,8 +13,9 @@ def from_file(name):
     file_path = Path(__file__).parent / 'js' / name
     return file_path.read_text(encoding='utf-8')
 
+
 SCRIPTS: Dict[str, str] = {
-    'chrome_csi': from_file('chrome.csi.js'),
+    'chrome_csi': from_file('chrome.csi.js'), 
     'chrome_app': from_file('chrome.app.js'),
     'chrome_runtime': from_file('chrome.runtime.js'),
     'chrome_load_times': from_file('chrome.load.times.js'),

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -15,7 +15,7 @@ def from_file(name):
 
 
 SCRIPTS: Dict[str, str] = {
-    'chrome_csi': from_file('chrome.csi.js'), 
+    'chrome_csi': from_file('chrome.csi.js'),
     'chrome_app': from_file('chrome.app.js'),
     'chrome_runtime': from_file('chrome.runtime.js'),
     'chrome_load_times': from_file('chrome.load.times.js'),

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -14,7 +14,7 @@ def from_file(name):
     return file_path.read_text(encoding='utf-8')
 
 SCRIPTS: Dict[str, str] = {
-    'chrome_csi': from_file('chrome.csi.js'),   
+    'chrome_csi': from_file('chrome.csi.js'),
     'chrome_app': from_file('chrome.app.js'),
     'chrome_runtime': from_file('chrome.runtime.js'),
     'chrome_load_times': from_file('chrome.load.times.js'),

--- a/playwright_stealth/stealth.py
+++ b/playwright_stealth/stealth.py
@@ -2,19 +2,19 @@
 import json
 from dataclasses import dataclass
 from typing import Tuple, Optional, Dict
+from pathlib import Path
 
-import pkg_resources
 from playwright.async_api import Page as AsyncPage
 from playwright.sync_api import Page as SyncPage
 
 
 def from_file(name):
     """Read script from ./js directory"""
-    return pkg_resources.resource_string('playwright_stealth', f'js/{name}').decode()
-
+    file_path = Path(__file__).parent / 'js' / name
+    return file_path.read_text(encoding='utf-8')
 
 SCRIPTS: Dict[str, str] = {
-    'chrome_csi': from_file('chrome.csi.js'),
+    'chrome_csi': from_file('chrome.csi.js'),   
     'chrome_app': from_file('chrome.app.js'),
     'chrome_runtime': from_file('chrome.runtime.js'),
     'chrome_load_times': from_file('chrome.load.times.js'),


### PR DESCRIPTION
pkg_resources is deprecated and as of pip 24 (+ Python 3.12) its not working anymore at all. Replacing with a simple file read.

Fixes https://github.com/AtuboDad/playwright_stealth/issues/22

This PR is a cleanup of @paveldudka PR https://github.com/AtuboDad/playwright_stealth/pull/24 to get the fix merged as soon as possible.